### PR TITLE
expose cost in the cluster config and use it to divide iteration space

### DIFF
--- a/conversions/lowerReplicateOp.h
+++ b/conversions/lowerReplicateOp.h
@@ -125,8 +125,40 @@ struct ConvertReplicateOp : public OpConversionPattern<mlir::avial::ReplicateOp>
         llvm::SmallVector<mlir::avial::ArrayPartitioningInfo> arrayPartitionInfoOutVec;
 
         int64_t total_iters = ub - lb;
-        int64_t base_chunk = total_iters / num_devices;
-        int64_t remainder = total_iters % num_devices;
+
+        // weight = 1/cost for each node, cost cannot be 0
+        std::vector<float> weights;
+        float weight_sum = 0.0f;
+
+        for (int i = 0; i < num_devices; i++)
+        {
+            float cost = 1.0f;
+            if (auto costAttr = mlir::dyn_cast<mlir::FloatAttr>(getDeviceAttribute(deviceVec[i], "cost")))
+            {
+                cost = costAttr.getValue().convertToFloat();
+            }
+
+            float weight = 1.0f / cost;
+            weights.push_back(weight);
+            weight_sum += weight;
+        }
+
+        std::vector<int64_t> chunk_sizes;
+        int64_t assigned_iters = 0;
+
+        for (int i = 0; i < num_devices; i++)
+        {
+            int64_t chunk = static_cast<int64_t>((weights[i] / weight_sum) * total_iters);
+            chunk_sizes.push_back(chunk);
+            assigned_iters += chunk;
+        }
+
+        // handle remainder iterations by adding 1 iteration to each device till all remainder iterations are assigned
+        int64_t remainder = total_iters - assigned_iters;
+        for (int i = 0; i < remainder; i++)
+        {
+            chunk_sizes[i % num_devices]++;
+        }
 
         llvm::SmallVector<mlir::Value> insVec(op.getReads().begin(),
                                               op.getReads().end());
@@ -212,7 +244,7 @@ struct ConvertReplicateOp : public OpConversionPattern<mlir::avial::ReplicateOp>
         int64_t current = constlowerBound;
         for (int i = 0; i < num_devices; ++i)
         {
-            int64_t chunk = base_chunk + (i < remainder ? 1 : 0);
+            int64_t chunk = chunk_sizes[i];
             int64_t start = current;
             int64_t end = start + chunk;
             current = end;

--- a/includes/system_config.h
+++ b/includes/system_config.h
@@ -13,6 +13,7 @@ struct GPUInfo {
 struct NodeInfo {
     std::string cpu_arch;
     std::vector<GPUInfo> gpus;
+    float cost;
 };
 
 struct ClusterInfo {
@@ -37,6 +38,7 @@ inline void from_json(const json& j, GPUInfo& g) {
 inline void from_json(const json& j, NodeInfo& n) {
     n.cpu_arch = j.at("cpu_arch").get<std::string>();
     n.gpus = j.at("gpus").get<std::vector<GPUInfo>>();
+    n.cost = j.value("cost", 1.0f);
 }
 
 inline void from_json(const json& j, ClusterInfo& c) {

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -26,6 +26,7 @@
 
 void attachDLTISpec(mlir::ModuleOp module, mlir::MLIRContext *context, SystemTopology);
 llvm::SmallVector<mlir::TargetDeviceSpecAttr> extractTargetDeviceSpecs(mlir::ModuleOp module);
+mlir::Attribute getDeviceAttribute(mlir::TargetDeviceSpecAttr deviceSpec, llvm::StringRef key);
 SystemTopology parseSystemConfig(llvm::StringRef configFile);
 
 void generateBroadcastCommunication(

--- a/libs/utils.cc
+++ b/libs/utils.cc
@@ -23,8 +23,8 @@ void attachDLTISpec(mlir::ModuleOp module, mlir::MLIRContext *context, SystemTop
             builder.getStringAttr("arch"),
             builder.getStringAttr(node.cpu_arch));
 
-        // Optional: cost based on number of GPUs or something else
-        float cost = node.gpus.empty() ? 1.0f : 0.5f;
+        // use cost from cluster config file
+        float cost = node.cost;
         auto costEntry = mlir::DataLayoutEntryAttr::get(
             builder.getStringAttr("cost"),
             builder.getF32FloatAttr(cost));
@@ -115,6 +115,22 @@ llvm::SmallVector<mlir::TargetDeviceSpecAttr> extractTargetDeviceSpecs(ModuleOp 
     }
 
     return targetSpecVec;
+}
+
+mlir::Attribute getDeviceAttribute(mlir::TargetDeviceSpecAttr deviceSpec, llvm::StringRef key)
+{
+    for (auto entry : deviceSpec.getEntries())
+    {
+        auto dle = mlir::dyn_cast<mlir::DataLayoutEntryAttr>(entry);
+        if (!dle) continue;
+
+        auto attrKey = dle.getKey().dyn_cast<mlir::StringAttr>();
+        if (!attrKey) continue;
+
+        if (attrKey.getValue() == key) return dle.getValue();
+    }
+
+    return nullptr;
 }
 
 SystemTopology parseSystemConfig(llvm::StringRef configFile)

--- a/tests/configs/system_config_4_cpu_with_costs.json
+++ b/tests/configs/system_config_4_cpu_with_costs.json
@@ -1,0 +1,33 @@
+{
+  "cluster": {
+    "world_size": 4,
+    "node_ids": [
+      "node0",
+      "node1",
+      "node2",
+      "node3"
+    ]
+  },
+  "nodes": {
+    "node0": {
+      "cpu_arch": "x86_64",
+      "gpus": [],
+      "cost": 0.25
+    },
+    "node1": {
+      "cpu_arch": "x86_64",
+      "gpus": [],
+      "cost": 0.90
+    },
+    "node2": {
+      "cpu_arch": "x86_64",
+      "gpus": [],
+      "cost": 1.5
+    },
+    "node3": {
+      "cpu_arch": "x86_64",
+      "gpus": [],
+      "cost": 0.55
+    }
+  }
+}


### PR DESCRIPTION
This PR exposes the cost parameter in the cluster configuration file and uses it to divide the iteration space. 

The cost parameter is optional at the moment to maintain compatibility with older config files. The cost defaults to 1.0 if it is not specified. An example config file with 4 cpus and costs for each of them has been added. Nodes with a higher cost are assigned a smaller chunk of the iteration space. This is calculated using a normalized weight parameter where each weight is equal to (1/cost) before normalization.

A getDeviceAttribute helper has also been added to utils to get the cost from the DLTI attributes during the lowering pass. This gives us a reusable way to query DLTI attributes in other passes too.