### PR TITLE
add cost aware task scheduling and runtime rank-to-node mapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(HWLOC REQUIRED IMPORTED_TARGET hwloc)
 
 add_library(dhir_runtime STATIC
-  libs/buildRankToNodeMap.cc
+  libs/runtimeHardwareMapping.cc
 )
 
 target_link_libraries(dhir_runtime

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ get_property(extension_libs GLOBAL PROPERTY MLIR_EXTENSION_LIBS)
 # add_link_options(-fsanitize=undefined)
 
 find_package(MPI REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(HWLOC REQUIRED IMPORTED_TARGET hwloc)
 
 add_library(dhir_runtime STATIC
   libs/buildRankToNodeMap.cc
@@ -57,6 +59,7 @@ add_library(dhir_runtime STATIC
 target_link_libraries(dhir_runtime
   PUBLIC
     MPI::MPI_CXX
+    PkgConfig::HWLOC
 )
 
 add_subdirectory(dialect)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,17 @@ get_property(extension_libs GLOBAL PROPERTY MLIR_EXTENSION_LIBS)
 # add_compile_options(-fsanitize=undefined)
 # add_link_options(-fsanitize=undefined)
 
+find_package(MPI REQUIRED)
+
+add_library(dhir_runtime STATIC
+  libs/buildRankToNodeMap.cc
+)
+
+target_link_libraries(dhir_runtime
+  PUBLIC
+    MPI::MPI_CXX
+)
+
 add_subdirectory(dialect)
 
 set(NO_RTTI "-fno-rtti")

--- a/conversions/avialirtompi.h
+++ b/conversions/avialirtompi.h
@@ -276,7 +276,8 @@ static Value createRuntimeTopology(ModuleOp module, ConversionPatternRewriter &r
 
     struct NodeInfo
     {
-        std::string globalName;
+        std::string nodeIdGlobalName;
+        std::string archGlobalName;
         int gpuCount;
         float cost;
     };
@@ -286,7 +287,7 @@ static Value createRuntimeTopology(ModuleOp module, ConversionPatternRewriter &r
     auto ptrTy = LLVM::LLVMPointerType::get(rewriter.getContext());
 
     // create LLVM structs to pass on to buildRankToNodeMap - has to mirror RuntimeNode/RuntimeTopology memory layout expected by runtime library
-    auto runtimeNodeTy = LLVM::LLVMStructType::getLiteral(rewriter.getContext(), {ptrTy, rewriter.getI32Type(), rewriter.getF32Type()});
+    auto runtimeNodeTy = LLVM::LLVMStructType::getLiteral(rewriter.getContext(), {ptrTy, ptrTy, rewriter.getI32Type(), rewriter.getF32Type()});
     auto runtimeTopologyTy = LLVM::LLVMStructType::getLiteral(rewriter.getContext(), {rewriter.getI32Type(), ptrTy});
 
     auto llvmI8Type = IntegerType::get(rewriter.getContext(), 8);
@@ -297,29 +298,45 @@ static Value createRuntimeTopology(ModuleOp module, ConversionPatternRewriter &r
     {
         auto targetSpec = cast<mlir::TargetDeviceSpecAttr>(deviceAttr);
         auto nodeIdAttr = getDeviceAttribute(targetSpec, "node_id");
+        auto archAttr = getDeviceAttribute(targetSpec, "arch");
         auto gpuCountAttr = getDeviceAttribute(targetSpec, "gpu_count");
         auto costAttr = getDeviceAttribute(targetSpec, "cost");
 
-        std::string nodeId = cast<StringAttr>(nodeIdAttr).getValue().str();
-        std::string terminated = nodeId;
-        terminated.push_back('\0');
+        std::string nodeIdTerminated = cast<StringAttr>(nodeIdAttr).getValue().str();
+        nodeIdTerminated.push_back('\0');
 
-        std::string globalName = "node_str_" + std::to_string(nodeIdx);
-        auto stringType = LLVM::LLVMArrayType::get(llvmI8Type, terminated.size());
-        auto stringAttr = StringAttr::get(rewriter.getContext(), StringRef(terminated.data(), terminated.size()));
+        std::string archTerminated = cast<StringAttr>(archAttr).getValue().str();
+        archTerminated.push_back('\0');
 
-        if (!module.lookupSymbol<LLVM::GlobalOp>(globalName))
+        std::string nodeIdGlobalName = "node_str_" + std::to_string(nodeIdx);
+        std::string archGlobalName = "arch_str_" + std::to_string(nodeIdx);
+        auto nodeIdStringType = LLVM::LLVMArrayType::get(llvmI8Type, nodeIdTerminated.size());
+        auto nodeIdStringAttr = StringAttr::get(rewriter.getContext(), StringRef(nodeIdTerminated.data(), nodeIdTerminated.size()));
+        auto archStringType = LLVM::LLVMArrayType::get(llvmI8Type, archTerminated.size());
+        auto archStringAttr = StringAttr::get(rewriter.getContext(), StringRef(archTerminated.data(), archTerminated.size()));
+
+        if (!module.lookupSymbol<LLVM::GlobalOp>(nodeIdGlobalName))
         {
             OpBuilder::InsertionGuard guard(rewriter);
             rewriter.setInsertionPointToStart(module.getBody());
 
             // emit global string constants containing node hostnames
-            rewriter.create<LLVM::GlobalOp>(loc, stringType, true, LLVM::Linkage::Internal, globalName, stringAttr);
+            rewriter.create<LLVM::GlobalOp>(loc, nodeIdStringType, true, LLVM::Linkage::Internal, nodeIdGlobalName, nodeIdStringAttr);
+        }
+
+        if (!module.lookupSymbol<LLVM::GlobalOp>(archGlobalName))
+        {
+            OpBuilder::InsertionGuard guard(rewriter);
+            rewriter.setInsertionPointToStart(module.getBody());
+
+            // emit global string constants containing node cpu arch
+            rewriter.create<LLVM::GlobalOp>(loc, archStringType, true, LLVM::Linkage::Internal, archGlobalName, archStringAttr);
         }
 
         NodeInfo info;
 
-        info.globalName = globalName;
+        info.nodeIdGlobalName = nodeIdGlobalName;
+        info.archGlobalName = archGlobalName;
         info.gpuCount = cast<IntegerAttr>(gpuCountAttr).getInt();
         info.cost = cast<FloatAttr>(costAttr).getValueAsDouble();
 
@@ -336,18 +353,22 @@ static Value createRuntimeTopology(ModuleOp module, ConversionPatternRewriter &r
     Value oneI64 = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI64Type(), rewriter.getI64IntegerAttr(1));
     Value oneI32 = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(1));
     Value twoI32 = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(2));
+    Value threeI32 = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(3));
 
     // populate RuntimeNode entries from collected topology information
     for (size_t i = 0; i < nodes.size(); i++)
     {
         Value nodeIndex = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI64Type(), rewriter.getI64IntegerAttr(i));
         Value nodePtr = rewriter.create<LLVM::GEPOp>(loc, ptrTy, runtimeNodeTy, nodeArray, ValueRange{nodeIndex});
-        Value nodeString = rewriter.create<LLVM::AddressOfOp>(loc, ptrTy, nodes[i].globalName);
+        Value nodeString = rewriter.create<LLVM::AddressOfOp>(loc, ptrTy, nodes[i].nodeIdGlobalName);
+        Value archString = rewriter.create<LLVM::AddressOfOp>(loc, ptrTy, nodes[i].archGlobalName);
         Value nodeIdField = rewriter.create<LLVM::GEPOp>(loc, ptrTy, runtimeNodeTy, nodePtr, ValueRange{zeroI64, zeroI32});
-        Value gpuCountField = rewriter.create<LLVM::GEPOp>(loc, ptrTy, runtimeNodeTy, nodePtr, ValueRange{zeroI64, oneI32});
-        Value costField = rewriter.create<LLVM::GEPOp>(loc, ptrTy, runtimeNodeTy, nodePtr, ValueRange{zeroI64, twoI32});
+        Value archField = rewriter.create<LLVM::GEPOp>(loc, ptrTy, runtimeNodeTy, nodePtr, ValueRange{zeroI64, oneI32});
+        Value gpuCountField = rewriter.create<LLVM::GEPOp>(loc, ptrTy, runtimeNodeTy, nodePtr, ValueRange{zeroI64, twoI32});
+        Value costField = rewriter.create<LLVM::GEPOp>(loc, ptrTy, runtimeNodeTy, nodePtr, ValueRange{zeroI64, threeI32});
 
         rewriter.create<LLVM::StoreOp>(loc, nodeString, nodeIdField);
+        rewriter.create<LLVM::StoreOp>(loc, archString, archField);
         rewriter.create<LLVM::StoreOp>(loc, rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(nodes[i].gpuCount)), gpuCountField);
         rewriter.create<LLVM::StoreOp>(loc, rewriter.create<LLVM::ConstantOp>(loc, rewriter.getF32Type(), rewriter.getF32FloatAttr(nodes[i].cost)), costField);
     }

--- a/conversions/avialirtompi.h
+++ b/conversions/avialirtompi.h
@@ -286,7 +286,7 @@ static Value createRuntimeTopology(ModuleOp module, ConversionPatternRewriter &r
 
     auto ptrTy = LLVM::LLVMPointerType::get(rewriter.getContext());
 
-    // create LLVM structs to pass on to buildRankToNodeMap - has to mirror RuntimeNode/RuntimeTopology memory layout expected by runtime library
+    // create LLVM structs to pass on to buildRankNodeMaps - has to mirror RuntimeNode/RuntimeTopology memory layout expected by runtime library
     auto runtimeNodeTy = LLVM::LLVMStructType::getLiteral(rewriter.getContext(), {ptrTy, ptrTy, rewriter.getI32Type(), rewriter.getF32Type()});
     auto runtimeTopologyTy = LLVM::LLVMStructType::getLiteral(rewriter.getContext(), {rewriter.getI32Type(), ptrTy});
 
@@ -473,7 +473,7 @@ struct ConvertScheduleOp : public OpConversionPattern<mlir::avial::ScheduleOp>
         Value rankMapPtr = rewriter.create<LLVM::IntToPtrOp>(loc, ptrTy, rankMapI64);
         Value nodeMapPtr = rewriter.create<LLVM::IntToPtrOp>(loc, ptrTy, nodeMapI64);
 
-        auto runtimeFunc = module.lookupSymbol<func::FuncOp>("buildRankToNodeMap");
+        auto runtimeFunc = module.lookupSymbol<func::FuncOp>("buildRankNodeMaps");
 
         // declare the runtime helper if it has not been emitted yet
         if (!runtimeFunc)
@@ -482,11 +482,11 @@ struct ConvertScheduleOp : public OpConversionPattern<mlir::avial::ScheduleOp>
             rewriter.setInsertionPointToStart(&module.getBodyRegion().front());
 
             auto fnType = rewriter.getFunctionType({topology.getType(), ptrTy, ptrTy}, {});
-            runtimeFunc = rewriter.create<func::FuncOp>(loc, "buildRankToNodeMap", fnType);
+            runtimeFunc = rewriter.create<func::FuncOp>(loc, "buildRankNodeMaps", fnType);
             runtimeFunc.setPrivate();
         }
 
-        // emit a call to the runtime function buildRankToNodeMap
+        // emit a call to the runtime function buildRankNodeMaps
         rewriter.create<func::CallOp>(loc, runtimeFunc, ValueRange{topology, rankMapPtr, nodeMapPtr});
 
         Value rankIndex = rewriter.create<arith::IndexCastOp>(loc, rewriter.getIndexType(), rank.getResult(0));

--- a/conversions/avialirtompi.h
+++ b/conversions/avialirtompi.h
@@ -269,6 +269,103 @@ static SmallVector<Value> materializeOpFoldResults(ConversionPatternRewriter &re
     return values;
 }
 
+static Value createRuntimeTopology(ModuleOp module, ConversionPatternRewriter &rewriter, Location loc)
+{
+    auto devicesAttr = module->getAttrOfType<ArrayAttr>("avial.target_devices");
+    assert(devicesAttr && "No avial.target_devices attribute found");
+
+    struct NodeInfo
+    {
+        std::string globalName;
+        int gpuCount;
+        float cost;
+    };
+
+    SmallVector<NodeInfo> nodes;
+
+    auto ptrTy = LLVM::LLVMPointerType::get(rewriter.getContext());
+
+    // create LLVM structs to pass on to buildRankToNodeMap - has to mirror RuntimeNode/RuntimeTopology memory layout expected by runtime library
+    auto runtimeNodeTy = LLVM::LLVMStructType::getLiteral(rewriter.getContext(), {ptrTy, rewriter.getI32Type(), rewriter.getF32Type()});
+    auto runtimeTopologyTy = LLVM::LLVMStructType::getLiteral(rewriter.getContext(), {rewriter.getI32Type(), ptrTy});
+
+    auto llvmI8Type = IntegerType::get(rewriter.getContext(), 8);
+
+    int nodeIdx = 0;
+
+    for (auto deviceAttr : devicesAttr)
+    {
+        auto targetSpec = cast<mlir::TargetDeviceSpecAttr>(deviceAttr);
+        auto nodeIdAttr = getDeviceAttribute(targetSpec, "node_id");
+        auto gpuCountAttr = getDeviceAttribute(targetSpec, "gpu_count");
+        auto costAttr = getDeviceAttribute(targetSpec, "cost");
+
+        std::string nodeId = cast<StringAttr>(nodeIdAttr).getValue().str();
+        std::string terminated = nodeId;
+        terminated.push_back('\0');
+
+        std::string globalName = "node_str_" + std::to_string(nodeIdx);
+        auto stringType = LLVM::LLVMArrayType::get(llvmI8Type, terminated.size());
+        auto stringAttr = StringAttr::get(rewriter.getContext(), StringRef(terminated.data(), terminated.size()));
+
+        if (!module.lookupSymbol<LLVM::GlobalOp>(globalName))
+        {
+            OpBuilder::InsertionGuard guard(rewriter);
+            rewriter.setInsertionPointToStart(module.getBody());
+
+            // emit global string constants containing node hostnames
+            rewriter.create<LLVM::GlobalOp>(loc, stringType, true, LLVM::Linkage::Internal, globalName, stringAttr);
+        }
+
+        NodeInfo info;
+
+        info.globalName = globalName;
+        info.gpuCount = cast<IntegerAttr>(gpuCountAttr).getInt();
+        info.cost = cast<FloatAttr>(costAttr).getValueAsDouble();
+
+        nodes.push_back(info);
+        nodeIdx++;
+    }
+
+    // allocate RuntimeNode[] on the stack
+    Value numNodes = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI64Type(), rewriter.getI64IntegerAttr(nodes.size()));
+    Value nodeArray = rewriter.create<LLVM::AllocaOp>(loc, ptrTy, runtimeNodeTy, numNodes);
+
+    Value zeroI64 = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI64Type(), rewriter.getI64IntegerAttr(0));
+    Value zeroI32 = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(0));
+    Value oneI64 = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI64Type(), rewriter.getI64IntegerAttr(1));
+    Value oneI32 = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(1));
+    Value twoI32 = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(2));
+
+    // populate RuntimeNode entries from collected topology information
+    for (size_t i = 0; i < nodes.size(); i++)
+    {
+        Value nodeIndex = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI64Type(), rewriter.getI64IntegerAttr(i));
+        Value nodePtr = rewriter.create<LLVM::GEPOp>(loc, ptrTy, runtimeNodeTy, nodeArray, ValueRange{nodeIndex});
+        Value nodeString = rewriter.create<LLVM::AddressOfOp>(loc, ptrTy, nodes[i].globalName);
+        Value nodeIdField = rewriter.create<LLVM::GEPOp>(loc, ptrTy, runtimeNodeTy, nodePtr, ValueRange{zeroI64, zeroI32});
+        Value gpuCountField = rewriter.create<LLVM::GEPOp>(loc, ptrTy, runtimeNodeTy, nodePtr, ValueRange{zeroI64, oneI32});
+        Value costField = rewriter.create<LLVM::GEPOp>(loc, ptrTy, runtimeNodeTy, nodePtr, ValueRange{zeroI64, twoI32});
+
+        rewriter.create<LLVM::StoreOp>(loc, nodeString, nodeIdField);
+        rewriter.create<LLVM::StoreOp>(loc, rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(nodes[i].gpuCount)), gpuCountField);
+        rewriter.create<LLVM::StoreOp>(loc, rewriter.create<LLVM::ConstantOp>(loc, rewriter.getF32Type(), rewriter.getF32FloatAttr(nodes[i].cost)), costField);
+    }
+
+    // build RuntimeTopology pointing at the node array
+    Value topology = rewriter.create<LLVM::AllocaOp>(loc, ptrTy, runtimeTopologyTy, oneI64);
+
+    Value numNodesField = rewriter.create<LLVM::GEPOp>(loc, ptrTy, runtimeTopologyTy, topology, ValueRange{zeroI64, zeroI32});
+
+    Value nodesField = rewriter.create<LLVM::GEPOp>(loc, ptrTy, runtimeTopologyTy, topology, ValueRange{zeroI64, oneI32});
+
+    Value numNodesConst = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(nodes.size()));
+
+    rewriter.create<LLVM::StoreOp>(loc, numNodesConst, numNodesField);
+    rewriter.create<LLVM::StoreOp>(loc, nodeArray, nodesField);
+
+    return topology;
+}
 
 struct ConvertScheduleOp : public OpConversionPattern<mlir::avial::ScheduleOp>
 {
@@ -331,6 +428,54 @@ struct ConvertScheduleOp : public OpConversionPattern<mlir::avial::ScheduleOp>
         auto getNodes = rewriter.create<mpi::CommSizeOp>(loc, mpi::RetvalType::get(rewriter.getContext()), rewriter.getI32Type(), comm->getResult(0));
 
         // End of MPI Boilerplate
+
+        Value topology = createRuntimeTopology(module, rewriter, loc);
+
+        auto devicesAttr = module->getAttrOfType<ArrayAttr>("avial.target_devices");
+        int numNodes = devicesAttr.size();
+
+        auto mapType = MemRefType::get({numNodes}, rewriter.getI32Type());
+
+        // allocate rank-node mapping tables for runtime initialization
+        Value rankToNodeMap = rewriter.create<memref::AllocOp>(loc, mapType);
+        Value nodeToRankMap = rewriter.create<memref::AllocOp>(loc, mapType);
+
+        auto ptrTy = LLVM::LLVMPointerType::get(rewriter.getContext());
+
+        // extract aligned pointers so we can pass raw pointers instead of a memref descriptor to the runtime function
+        Value rankMapIdxPtr = rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(loc, rankToNodeMap);
+        Value nodeMapIdxPtr = rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(loc, nodeToRankMap);
+
+        Value rankMapI64 = rewriter.create<arith::IndexCastOp>(loc, rewriter.getI64Type(), rankMapIdxPtr);
+        Value nodeMapI64 = rewriter.create<arith::IndexCastOp>(loc, rewriter.getI64Type(), nodeMapIdxPtr);
+
+        Value rankMapPtr = rewriter.create<LLVM::IntToPtrOp>(loc, ptrTy, rankMapI64);
+        Value nodeMapPtr = rewriter.create<LLVM::IntToPtrOp>(loc, ptrTy, nodeMapI64);
+
+        auto runtimeFunc = module.lookupSymbol<func::FuncOp>("buildRankToNodeMap");
+
+        // declare the runtime helper if it has not been emitted yet
+        if (!runtimeFunc)
+        {
+            OpBuilder::InsertionGuard guard(rewriter);
+            rewriter.setInsertionPointToStart(&module.getBodyRegion().front());
+
+            auto fnType = rewriter.getFunctionType({topology.getType(), ptrTy, ptrTy}, {});
+            runtimeFunc = rewriter.create<func::FuncOp>(loc, "buildRankToNodeMap", fnType);
+            runtimeFunc.setPrivate();
+        }
+
+        // emit a call to the runtime function buildRankToNodeMap
+        rewriter.create<func::CallOp>(loc, runtimeFunc, ValueRange{topology, rankMapPtr, nodeMapPtr});
+
+        Value rankIndex = rewriter.create<arith::IndexCastOp>(loc, rewriter.getIndexType(), rank.getResult(0));
+        Value rankNode = rewriter.create<memref::LoadOp>(loc, rankToNodeMap, ValueRange{rankIndex});
+
+        // we take target device information from the taskOp rather than relying on ordering in the DLTI attributes
+        DenseMap<Attribute, int> deviceToIndex;
+
+        for (auto [idx, dev] : llvm::enumerate(devicesAttr))
+            deviceToIndex[dev] = idx;
 
         // Check if there's a scf.for loop wrapping the tasks
         mlir::scf::ForOp outerLoop = nullptr;
@@ -398,14 +543,21 @@ struct ConvertScheduleOp : public OpConversionPattern<mlir::avial::ScheduleOp>
         {
             llvm::DenseMap<Value, Value> gpuBufferMap;
             llvm::SmallVector<Value> toBroadcast;
-            int taskId = 0;
-            
+
             for (auto task : level)
             {
-                auto taskIDOp = rewriter.create<mlir::arith::ConstantOp>(loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(taskId));
-                auto taskIdModNodes = rewriter.create<mlir::arith::RemSIOp>(loc, taskIDOp->getResult(0), getNodes->getResult(1));
-                auto cond = rewriter.create<arith::CmpIOp>(loc, rewriter.getI1Type(), arith::CmpIPredicate::eq, rank.getResult(0), taskIdModNodes.getResult());
-                
+                auto taskOp = dyn_cast<avial::TaskOp>(task->op);
+                Attribute targetDevice = taskOp.getTarget();
+
+                // if task target device has no matches in the deviceToIndex map, something is broken on our end.
+                // this should not create UB on the users' end
+                assert(deviceToIndex.count(targetDevice) && "Task target device not found in deviceToIndex map");
+
+                int targetNodeIdx = deviceToIndex[targetDevice];
+
+                auto targetNode = rewriter.create<arith::ConstantIntOp>(loc, targetNodeIdx, 32);
+                auto cond = rewriter.create<arith::CmpIOp>(loc, rewriter.getI1Type(), arith::CmpIPredicate::eq, rankNode, targetNode);
+
                 rewriter.create<mlir::scf::IfOp>(loc, cond, [&](OpBuilder &ifbuilder, Location loc)
                 {
                     Block &taskBlock = task->op->getRegion(0).front(); 
@@ -512,30 +664,30 @@ struct ConvertScheduleOp : public OpConversionPattern<mlir::avial::ScheduleOp>
                         }
                     }
 
-                    ifbuilder.create<mlir::scf::YieldOp>(loc);
-                });
-
-                ++taskId;
+                    ifbuilder.create<mlir::scf::YieldOp>(loc); });
             }
 
             rewriter.create<mpi::Barrier>(loc, retVal, comm->getResult(0));
 
             // Communication code
-            auto one = rewriter.create<mlir::arith::ConstantOp>(loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(1));
-            auto zero = rewriter.create<mlir::arith::ConstantOp>(loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(0));
             auto tag = rewriter.create<mlir::arith::ConstantOp>(loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(0));
-
-            taskId = 0;
 
             for (auto task : level)
             {
                 auto taskOp = dyn_cast<mlir::avial::TaskOp>(task->op);
+                Attribute targetDevice = taskOp.getTarget();
+
+                assert(deviceToIndex.count(targetDevice) && "Task target device not found in deviceToIndex map");
+
+                int targetNodeIdx = deviceToIndex[targetDevice];
+
                 llvm::ArrayRef outRanges = taskOp.getOutRanges();
                 
                 // Get the base buffer from mapping (now subviews are in mapping!)
                 Value buffer = mapping.lookupOrNull(task->writes[0]);
-                
-                if (!buffer) {
+
+                if (!buffer)
+                {
                     llvm::errs() << "ERROR: Buffer not found in mapping\n";
                     return failure();
                 }
@@ -572,7 +724,7 @@ struct ConvertScheduleOp : public OpConversionPattern<mlir::avial::ScheduleOp>
                         rewriter.getIndexAttr(0)
                     };
                     sizes = {
-                        rewriter.getIndexAttr((outRanges[1] - outRanges[0])*10000),
+                        rewriter.getIndexAttr((outRanges[1] - outRanges[0])),
                         rewriter.getIndexAttr(shape[1])
                     };
                     strides = {
@@ -611,42 +763,40 @@ struct ConvertScheduleOp : public OpConversionPattern<mlir::avial::ScheduleOp>
                 Value subBuffer = rewriter.create<memref::SubViewOp>(
                     loc, sourceBuffer, offsets, sizes, strides);
 
-                // Default Communication
-                auto cond = rewriter.create<arith::CmpIOp>(loc, rewriter.getI1Type(), arith::CmpIPredicate::eq, rank.getResult(0), zero.getResult());
-                auto ifOp = rewriter.create<mlir::scf::IfOp>(loc, mlir::TypeRange{}, cond, true);
-                OpBuilder thenBuilder = ifOp.getThenBodyBuilder(rewriter.getListener());
-                OpBuilder elseBuilder = ifOp.getElseBodyBuilder(rewriter.getListener());
+                // gather non-root results onto node 0
+                if (targetNodeIdx != 0)
+                {
+                    Value rootNodeIndex = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+                    Value rootRank = rewriter.create<memref::LoadOp>(loc, nodeToRankMap, ValueRange{rootNodeIndex});
 
-                // Receive
-                auto taskIDOp = thenBuilder.create<mlir::arith::ConstantOp>(loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(taskId));
-                auto taskIdModNodes = thenBuilder.create<mlir::arith::RemSIOp>(loc, taskIDOp->getResult(0), getNodes->getResult(1));
-                auto innercond = thenBuilder.create<arith::CmpIOp>(loc, rewriter.getI1Type(), arith::CmpIPredicate::ne, zero.getResult(), taskIdModNodes.getResult());
-                auto innerIf = thenBuilder.create<mlir::scf::IfOp>(loc, mlir::TypeRange{}, innercond, false);
-                auto innerThenBuilder = innerIf.getThenBodyBuilder(thenBuilder.getListener());
+                    Value ownerNodeIndex = rewriter.create<arith::ConstantIndexOp>(loc, targetNodeIdx);
+                    Value ownerRank = rewriter.create<memref::LoadOp>(loc, nodeToRankMap, ValueRange{ownerNodeIndex});
 
-                auto recvOp = innerThenBuilder.create<mlir::mpi::RecvOp>(
-                    loc, retVal, subBuffer, tag.getResult(), taskIdModNodes->getResult(0), comm->getResult(0));
+                    auto isRoot = rewriter.create<arith::CmpIOp>(loc, rewriter.getI1Type(), arith::CmpIPredicate::eq, rank.getResult(0), rootRank);
+                    auto isOwner = rewriter.create<arith::CmpIOp>(loc, rewriter.getI1Type(), arith::CmpIPredicate::eq, rank.getResult(0), ownerRank);
 
-                // Send
-                auto elsetaskIDOp = elseBuilder.create<mlir::arith::ConstantOp>(loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(taskId));
-                auto elsetaskIdModNodes = elseBuilder.create<mlir::arith::RemSIOp>(loc, elsetaskIDOp->getResult(0), getNodes->getResult(1));
-                auto elsecond = elseBuilder.create<arith::CmpIOp>(loc, rewriter.getI1Type(), arith::CmpIPredicate::eq, rank.getResult(0), elsetaskIdModNodes.getResult());
-                auto elseinnerIf = elseBuilder.create<mlir::scf::IfOp>(loc, mlir::TypeRange{}, elsecond, false);
-                auto elseinnerThenBuilder = elseinnerIf.getThenBodyBuilder(elseBuilder.getListener());
+                    auto ifOp = rewriter.create<mlir::scf::IfOp>(loc, mlir::TypeRange{}, isRoot, true);
+                    OpBuilder thenBuilder = ifOp.getThenBodyBuilder(rewriter.getListener());
+                    OpBuilder elseBuilder = ifOp.getElseBodyBuilder(rewriter.getListener());
 
-                auto sendOp = elseinnerThenBuilder.create<mlir::mpi::SendOp>(
-                    loc, retVal, subBuffer, tag.getResult(), zero, comm->getResult(0));
+                    thenBuilder.create<mlir::mpi::RecvOp>(loc, retVal, subBuffer, tag.getResult(), ownerRank, comm->getResult(0));
+
+                    auto sendIf = elseBuilder.create<mlir::scf::IfOp>(loc, mlir::TypeRange{}, isOwner, false);
+                    auto sendBuilder = sendIf.getThenBodyBuilder(elseBuilder.getListener());
+                    sendBuilder.create<mlir::mpi::SendOp>(loc, retVal, subBuffer, tag.getResult(), rootRank, comm->getResult(0));
+                }
 
                 // Broadcast
                 BoolAttr needBroadcast = mlir::dyn_cast<mlir::BoolAttr>(taskOp->getAttr("needBroadcast"));
                 if (needBroadcast && needBroadcast.getValue())
                     toBroadcast.push_back(subBuffer);
-
-                ++taskId;
             }
 
+            Value broadcastRootNodeIndex = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+            Value broadcastRootRank = rewriter.create<memref::LoadOp>(loc, nodeToRankMap, ValueRange{broadcastRootNodeIndex});
+
             generateBroadcastCommunication(
-                rewriter, loc, toBroadcast, rank.getResult(0), zero.getResult(),
+                rewriter, loc, toBroadcast, rank.getResult(0), broadcastRootRank,
                 comm->getResult(0), retVal, tag.getResult(), getNodes->getResult(1));
 
             toBroadcast.clear();

--- a/conversions/lowerReplicateOp.h
+++ b/conversions/lowerReplicateOp.h
@@ -138,7 +138,7 @@ struct ConvertReplicateOp : public OpConversionPattern<mlir::avial::ReplicateOp>
                 cost = costAttr.getValue().convertToFloat();
             }
 
-            assert(cost > 0.0f);
+            if (cost <= 0.0f) llvm::report_fatal_error("cost needs to be > 0");
 
             float weight = 1.0f / cost;
             weights.push_back(weight);
@@ -157,6 +157,8 @@ struct ConvertReplicateOp : public OpConversionPattern<mlir::avial::ReplicateOp>
 
         // handle remainder iterations by adding 1 iteration to each device till all remainder iterations are assigned
         int64_t remainder = total_iters - assigned_iters;
+        assert(remainder >= 0 && remainder < num_devices && "remainder should be in [0,num_devices)");
+
         for (int i = 0; i < remainder; i++)
         {
             chunk_sizes[i % num_devices]++;

--- a/conversions/lowerReplicateOp.h
+++ b/conversions/lowerReplicateOp.h
@@ -125,8 +125,42 @@ struct ConvertReplicateOp : public OpConversionPattern<mlir::avial::ReplicateOp>
         llvm::SmallVector<mlir::avial::ArrayPartitioningInfo> arrayPartitionInfoOutVec;
 
         int64_t total_iters = ub - lb;
-        int64_t base_chunk = total_iters / num_devices;
-        int64_t remainder = total_iters % num_devices;
+
+        // weight = 1/cost for each node, cost cannot be 0
+        std::vector<float> weights;
+        float weight_sum = 0.0f;
+
+        for (int i = 0; i < num_devices; i++)
+        {
+            float cost = 1.0f;
+            if (auto costAttr = mlir::dyn_cast<mlir::FloatAttr>(getDeviceAttribute(deviceVec[i], "cost")))
+            {
+                cost = costAttr.getValue().convertToFloat();
+            }
+
+            assert(cost > 0.0f);
+
+            float weight = 1.0f / cost;
+            weights.push_back(weight);
+            weight_sum += weight;
+        }
+
+        std::vector<int64_t> chunk_sizes;
+        int64_t assigned_iters = 0;
+
+        for (int i = 0; i < num_devices; i++)
+        {
+            int64_t chunk = static_cast<int64_t>((weights[i] / weight_sum) * total_iters);
+            chunk_sizes.push_back(chunk);
+            assigned_iters += chunk;
+        }
+
+        // handle remainder iterations by adding 1 iteration to each device till all remainder iterations are assigned
+        int64_t remainder = total_iters - assigned_iters;
+        for (int i = 0; i < remainder; i++)
+        {
+            chunk_sizes[i % num_devices]++;
+        }
 
         llvm::SmallVector<mlir::Value> insVec(op.getReads().begin(),
                                               op.getReads().end());
@@ -212,7 +246,7 @@ struct ConvertReplicateOp : public OpConversionPattern<mlir::avial::ReplicateOp>
         int64_t current = constlowerBound;
         for (int i = 0; i < num_devices; ++i)
         {
-            int64_t chunk = base_chunk + (i < remainder ? 1 : 0);
+            int64_t chunk = chunk_sizes[i];
             int64_t start = current;
             int64_t end = start + chunk;
             current = end;

--- a/includes/system_config.h
+++ b/includes/system_config.h
@@ -13,6 +13,7 @@ struct GPUInfo {
 struct NodeInfo {
     std::string cpu_arch;
     std::vector<GPUInfo> gpus;
+    float cost;
 };
 
 struct ClusterInfo {
@@ -37,6 +38,7 @@ inline void from_json(const json& j, GPUInfo& g) {
 inline void from_json(const json& j, NodeInfo& n) {
     n.cpu_arch = j.at("cpu_arch").get<std::string>();
     n.gpus = j.at("gpus").get<std::vector<GPUInfo>>();
+    n.cost = j.value("cost", 1.0f);
 }
 
 inline void from_json(const json& j, ClusterInfo& c) {

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -26,6 +26,7 @@
 
 void attachDLTISpec(mlir::ModuleOp module, mlir::MLIRContext *context, SystemTopology);
 llvm::SmallVector<mlir::TargetDeviceSpecAttr> extractTargetDeviceSpecs(mlir::ModuleOp module);
+mlir::Attribute getDeviceAttribute(mlir::TargetDeviceSpecAttr deviceSpec, llvm::StringRef key);
 SystemTopology parseSystemConfig(llvm::StringRef configFile);
 
 void generateBroadcastCommunication(

--- a/libs/buildRankToNodeMap.cc
+++ b/libs/buildRankToNodeMap.cc
@@ -1,0 +1,71 @@
+#include "runtimeTopology.h"
+
+#include <mpi.h>
+
+#include <cstring>
+#include <cstdio>
+
+extern "C" void buildRankToNodeMap(
+    const RuntimeTopology *topology,
+    int *rankToNodeMap,
+    int *nodeToRankMap)
+{
+    int worldSize;
+
+    MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+
+    if (worldSize != topology->numNodes)
+    {
+        fprintf(stderr, "world size %d does not match configured node count %d\n", worldSize, topology->numNodes);
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    for (int i = 0; i < topology->numNodes; i++)
+    {
+        rankToNodeMap[i] = -1;
+        nodeToRankMap[i] = -1;
+    }
+
+    char hostname[MPI_MAX_PROCESSOR_NAME];
+    int namelen;
+
+    MPI_Get_processor_name(hostname, &namelen);
+
+    int matchedIdx = -1;
+
+    for (int i = 0; i < topology->numNodes; i++)
+    {
+        if (std::strcmp(hostname, topology->nodes[i].nodeId) == 0)
+        {
+            matchedIdx = i;
+            break;
+        }
+    }
+
+    if (matchedIdx == -1)
+    {
+        fprintf(stderr, "hostname %s was not found in the cluster configuration\n", hostname);
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    MPI_Allgather(&matchedIdx, 1, MPI_INT, rankToNodeMap, 1, MPI_INT, MPI_COMM_WORLD);
+
+    for (int r = 0; r < worldSize; r++)
+    {
+        int nodeIdx = rankToNodeMap[r];
+
+        if (nodeIdx < 0 || nodeIdx >= topology->numNodes)
+        {
+            fprintf(stderr, "invalid node index %d nodeIdx from rank %d\n", nodeIdx, r);
+            MPI_Abort(MPI_COMM_WORLD, 1);
+        }
+
+        if (nodeToRankMap[nodeIdx] != -1)
+        {
+            fprintf(stderr, "multiple nodes with hostname %s\n", topology->nodes[nodeIdx].nodeId);
+            MPI_Abort(MPI_COMM_WORLD, 1);
+        }
+
+        nodeToRankMap[nodeIdx] = r;
+    }
+}

--- a/libs/buildRankToNodeMap.cc
+++ b/libs/buildRankToNodeMap.cc
@@ -2,70 +2,109 @@
 
 #include <mpi.h>
 
+#include <hwloc.h>
+#include <sys/utsname.h>
+
 #include <cstring>
 #include <cstdio>
+#include <vector>
 
-extern "C" void buildRankToNodeMap(
+struct DiscoveredNode
+{
+    char cpuArch[32];
+    int gpuCount;
+};
+
+static void discoverNode(DiscoveredNode *node)
+{
+    struct utsname sysinfo;
+    uname(&sysinfo);
+
+    strncpy(node->cpuArch, sysinfo.machine, sizeof(node->cpuArch) - 1);
+    node->cpuArch[sizeof(node->cpuArch)-1] = '\0';
+
+    hwloc_topology_t topology;
+    hwloc_topology_init(&topology);
+    // hwloc_topology_set_io_types_filter(topology, HWLOC_TYPE_FILTER_KEEP_IMPORTANT);
+    hwloc_topology_load(topology);
+
+    int gpuCount = 0;
+    hwloc_obj_t obj = nullptr;
+
+    while((obj=hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_PCI_DEVICE, obj)) != nullptr)
+    {
+        if (obj->attr && obj->attr->pcidev.class_id >> 8 == 0x03)
+        {
+            gpuCount++;
+        }
+    }
+
+    node->gpuCount = gpuCount;
+
+    hwloc_topology_destroy(topology);
+}
+
+static bool matchNode(const RuntimeNode &cfg, const DiscoveredNode &local)
+{
+    if (strcmp(cfg.cpuArch, local.cpuArch) != 0) return false;
+    if (cfg.gpuCount != local.gpuCount) return false;
+    return true;
+}
+
+extern "C" void
+buildRankToNodeMap(
     const RuntimeTopology *topology,
     int *rankToNodeMap,
     int *nodeToRankMap)
 {
-    int worldSize;
-
+    int worldRank, worldSize;
+    MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
     MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
 
     if (worldSize != topology->numNodes)
     {
-        fprintf(stderr, "world size %d does not match configured node count %d\n", worldSize, topology->numNodes);
-        MPI_Abort(MPI_COMM_WORLD, 1);
+        printf("Number of ranks != number of nodes\n");
+        MPI_Abort(MPI_COMM_WORLD, -1);
     }
 
-    for (int i = 0; i < topology->numNodes; i++)
+    DiscoveredNode node;
+    discoverNode(&node);
+
+    std::vector<DiscoveredNode> rankHardware(worldSize);
+    MPI_Gather(&node, sizeof(DiscoveredNode), MPI_BYTE, rankHardware.data(), sizeof(DiscoveredNode), MPI_BYTE, 0, MPI_COMM_WORLD);
+
+    std::vector<int> rankToNode(worldSize, -1);
+    std::vector<int> nodeToRank(topology->numNodes, -1);
+
+    if (worldRank == 0)
     {
-        rankToNodeMap[i] = -1;
-        nodeToRankMap[i] = -1;
-    }
-
-    char hostname[MPI_MAX_PROCESSOR_NAME];
-    int namelen;
-
-    MPI_Get_processor_name(hostname, &namelen);
-
-    int matchedIdx = -1;
-
-    for (int i = 0; i < topology->numNodes; i++)
-    {
-        if (std::strcmp(hostname, topology->nodes[i].nodeId) == 0)
+        for(int r = 0; r < worldSize; r++)
         {
-            matchedIdx = i;
-            break;
+            const auto &info = rankHardware[r];
+
+            for (int n = 0; n < topology->numNodes; n++)
+            {
+                if (nodeToRank[n] != -1) continue;
+
+                if (matchNode(topology->nodes[n], info))
+                {
+                    rankToNode[r] = n;
+                    nodeToRank[n] = r;
+                    break;
+                }
+            }
+
+            if (rankToNode[r] == -1)
+            {
+                printf("No node match for rank %d\n", r);
+                MPI_Abort(MPI_COMM_WORLD, -1);
+            }
         }
     }
 
-    if (matchedIdx == -1)
-    {
-        fprintf(stderr, "hostname %s was not found in the cluster configuration\n", hostname);
-        MPI_Abort(MPI_COMM_WORLD, 1);
-    }
+    MPI_Bcast(rankToNode.data(), worldSize, MPI_INT, 0, MPI_COMM_WORLD);
+    MPI_Bcast(nodeToRank.data(), topology->numNodes, MPI_INT, 0, MPI_COMM_WORLD);
 
-    MPI_Allgather(&matchedIdx, 1, MPI_INT, rankToNodeMap, 1, MPI_INT, MPI_COMM_WORLD);
-
-    for (int r = 0; r < worldSize; r++)
-    {
-        int nodeIdx = rankToNodeMap[r];
-
-        if (nodeIdx < 0 || nodeIdx >= topology->numNodes)
-        {
-            fprintf(stderr, "invalid node index %d nodeIdx from rank %d\n", nodeIdx, r);
-            MPI_Abort(MPI_COMM_WORLD, 1);
-        }
-
-        if (nodeToRankMap[nodeIdx] != -1)
-        {
-            fprintf(stderr, "multiple nodes with hostname %s\n", topology->nodes[nodeIdx].nodeId);
-            MPI_Abort(MPI_COMM_WORLD, 1);
-        }
-
-        nodeToRankMap[nodeIdx] = r;
-    }
+    for (int i = 0; i < worldSize; i++) rankToNodeMap[i] = rankToNode[i];
+    for (int i = 0; i < topology->numNodes; i++) nodeToRankMap[i] = nodeToRank[i];
 }

--- a/libs/runtimeHardwareMapping.cc
+++ b/libs/runtimeHardwareMapping.cc
@@ -25,15 +25,18 @@ static void discoverNode(DiscoveredNode *node)
 
     hwloc_topology_t topology;
     hwloc_topology_init(&topology);
-    // hwloc_topology_set_io_types_filter(topology, HWLOC_TYPE_FILTER_KEEP_IMPORTANT);
+    hwloc_topology_set_io_types_filter(topology, HWLOC_TYPE_FILTER_KEEP_IMPORTANT);
     hwloc_topology_load(topology);
 
     int gpuCount = 0;
     hwloc_obj_t obj = nullptr;
 
+    constexpr unsigned PCI_VENDOR_NVIDIA = 0x10de;
+
     while((obj=hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_PCI_DEVICE, obj)) != nullptr)
     {
-        if (obj->attr && obj->attr->pcidev.class_id >> 8 == 0x03)
+        // todo: compute capability isn't verified here. assumes any nvidia gpu is sm61 compatible. verify via CUDA driver API.
+        if (obj->attr && obj->attr->pcidev.class_id >> 8 == 0x03 && obj->attr->pcidev.vendor_id == PCI_VENDOR_NVIDIA)
         {
             gpuCount++;
         }
@@ -52,7 +55,7 @@ static bool matchNode(const RuntimeNode &cfg, const DiscoveredNode &local)
 }
 
 extern "C" void
-buildRankToNodeMap(
+buildRankNodeMaps(
     const RuntimeTopology *topology,
     int *rankToNodeMap,
     int *nodeToRankMap)

--- a/libs/runtimeTopology.h
+++ b/libs/runtimeTopology.h
@@ -1,0 +1,17 @@
+#ifndef RUNTIMETOPOLOGY_H
+#define RUNTIMETOPOLOGY_H
+
+struct RuntimeNode
+{
+    const char *nodeId;
+    int gpuCount;
+    float cost;
+};
+
+struct RuntimeTopology
+{
+    int numNodes;
+    RuntimeNode *nodes;
+};
+
+#endif

--- a/libs/runtimeTopology.h
+++ b/libs/runtimeTopology.h
@@ -4,6 +4,7 @@
 struct RuntimeNode
 {
     const char *nodeId;
+    const char *cpuArch;
     int gpuCount;
     float cost;
 };

--- a/libs/utils.cc
+++ b/libs/utils.cc
@@ -23,8 +23,8 @@ void attachDLTISpec(mlir::ModuleOp module, mlir::MLIRContext *context, SystemTop
             builder.getStringAttr("arch"),
             builder.getStringAttr(node.cpu_arch));
 
-        // Optional: cost based on number of GPUs or something else
-        float cost = node.gpus.empty() ? 1.0f : 0.5f;
+        // use cost from cluster config file
+        float cost = node.cost;
         auto costEntry = mlir::DataLayoutEntryAttr::get(
             builder.getStringAttr("cost"),
             builder.getF32FloatAttr(cost));
@@ -117,6 +117,22 @@ llvm::SmallVector<mlir::TargetDeviceSpecAttr> extractTargetDeviceSpecs(ModuleOp 
     return targetSpecVec;
 }
 
+mlir::Attribute getDeviceAttribute(mlir::TargetDeviceSpecAttr deviceSpec, llvm::StringRef key)
+{
+    for (auto entry : deviceSpec.getEntries())
+    {
+        auto dle = mlir::dyn_cast<mlir::DataLayoutEntryAttr>(entry);
+        if (!dle) continue;
+
+        auto attrKey = mlir::dyn_cast<mlir::StringAttr>(dle.getKey());
+        if (!attrKey) continue;
+
+        if (attrKey.getValue() == key) return dle.getValue();
+    }
+
+    return nullptr;
+}
+
 SystemTopology parseSystemConfig(llvm::StringRef configFile)
 {
 
@@ -161,7 +177,7 @@ SystemTopology parseSystemConfig(llvm::StringRef configFile)
 /// @param loc Location for the generated operations
 /// @param toBroadcast Vector of sub-buffers that need to be broadcast
 /// @param rank The rank value (result of MPI rank query)
-/// @param zero Constant zero value
+/// @param rootRank The MPI rank from which data is broadcast
 /// @param comm The MPI communicator
 /// @param retVal Return type for MPI operations
 /// @param tag Tag for MPI operations
@@ -171,7 +187,7 @@ void generateBroadcastCommunication(
     Location loc,
     SmallVectorImpl<Value> &toBroadcast,
     Value rank,
-    Value zero,
+    Value rootRank,
     Value comm,
     mlir::Type retVal,
     Value tag,
@@ -282,13 +298,15 @@ void generateBroadcastCommunication(
     llvm::errs() << "Created combined broadcast buffer\n";
 
     // Generate broadcast communication using Send/Recv
-    // Rank 0 sends to all other ranks, remaining ranks receive from rank 0
+    // The rank corresponding to node0 acts as the broadcast root
+    // The broadcast root sends to all non-root ranks
+    // All other ranks receive from the broadcast root
     auto cond = rewriter.create<arith::CmpIOp>(
         loc,
         rewriter.getI1Type(),
         arith::CmpIPredicate::eq,
         rank,
-        zero);
+        rootRank);
 
     auto ifOp = rewriter.create<mlir::scf::IfOp>(
         loc,
@@ -296,17 +314,13 @@ void generateBroadcastCommunication(
         cond,
         true);
 
-    // Then block: Rank 0 - Send to all other ranks
+    // Then block: Broadcast root - Send to all non-root ranks
     OpBuilder thenBuilder = ifOp.getThenBodyBuilder(rewriter.getListener());
 
     // Get total number of nodes/ranks
-    // Assuming you have getNodes available in context, otherwise pass as parameter
-    // We need to send to ranks 1, 2, 3, ... N-1
-
-    // Create a loop to send to all ranks except rank 0
-    // for (i = 1; i < num_ranks; i++) { send to rank i }
-
-    auto one = thenBuilder.create<arith::ConstantIndexOp>(loc, 1);
+    // Create a loop over all ranks
+    // for (i=0; i < numRanks; i++)
+    auto zeroIndex = thenBuilder.create<arith::ConstantIndexOp>(loc, 0);
     auto step = thenBuilder.create<arith::ConstantIndexOp>(loc, 1);
 
     // Convert numRanks to index type if it's not already
@@ -319,7 +333,7 @@ void generateBroadcastCommunication(
             numRanks);
     }
 
-    auto forOp = thenBuilder.create<scf::ForOp>(loc, one, numRanksIndex, step);
+    auto forOp = thenBuilder.create<scf::ForOp>(loc, zeroIndex, numRanksIndex, step);
     OpBuilder forBuilder(forOp.getBody(), forOp.getBody()->begin());
 
     // Get loop induction variable (target rank)
@@ -331,8 +345,11 @@ void generateBroadcastCommunication(
         rewriter.getI32Type(),
         targetRank);
 
-    // Send to this rank
-    auto sendOp = forBuilder.create<mlir::mpi::SendOp>(
+    // Skip sending to the broadcast root itself
+    auto sendCond = forBuilder.create<arith::CmpIOp>(loc, rewriter.getI1Type(), arith::CmpIPredicate::ne, targetRankI32, rootRank);
+    auto sendIf = forBuilder.create<scf::IfOp>(loc, mlir::TypeRange{}, sendCond, false);
+    OpBuilder sendBuilder = sendIf.getThenBodyBuilder(forBuilder.getListener());
+    auto sendOp = sendBuilder.create<mlir::mpi::SendOp>(
         loc,
         retVal,          // return type
         broadcastBuffer, // buffer to send
@@ -341,9 +358,9 @@ void generateBroadcastCommunication(
         comm             // communicator
     );
 
-    llvm::errs() << "Generated broadcast sends from rank 0 to all other ranks\n";
+    llvm::errs() << "Generated broadcast sends from broadcast root to all other ranks\n";
 
-    // Else block: Other ranks - Receive from rank 0
+    // Else block: Other ranks - Receive from broadcast root
     OpBuilder elseBuilder = ifOp.getElseBodyBuilder(rewriter.getListener());
 
     auto recvOp = elseBuilder.create<mlir::mpi::RecvOp>(
@@ -351,10 +368,10 @@ void generateBroadcastCommunication(
         retVal,          // return type
         broadcastBuffer, // buffer to receive into
         tag,             // tag
-        zero,            // source rank (0)
+        rootRank,        // source rank (broadcast root)
         comm             // communicator
     );
 
-    llvm::errs() << "Generated broadcast receive for other ranks from rank 0\n";
+    llvm::errs() << "Generated broadcast receive for other ranks from broadcast root\n";
     llvm::errs() << "=== Broadcast Communication Complete ===\n\n";
 }

--- a/tests/configs/system_config_4_cpu_with_costs.json
+++ b/tests/configs/system_config_4_cpu_with_costs.json
@@ -1,0 +1,33 @@
+{
+  "cluster": {
+    "world_size": 4,
+    "node_ids": [
+      "node0",
+      "node1",
+      "node2",
+      "node3"
+    ]
+  },
+  "nodes": {
+    "node0": {
+      "cpu_arch": "x86_64",
+      "gpus": [],
+      "cost": 0.25
+    },
+    "node1": {
+      "cpu_arch": "x86_64",
+      "gpus": [],
+      "cost": 0.90
+    },
+    "node2": {
+      "cpu_arch": "x86_64",
+      "gpus": [],
+      "cost": 1.5
+    },
+    "node3": {
+      "cpu_arch": "x86_64",
+      "gpus": [],
+      "cost": 0.55
+    }
+  }
+}


### PR DESCRIPTION
This PR exposes the cost parameter in the cluster configuration file, uses it to divide the iteration space and adds runtime rank-to-node and node-to-rank mappings for task execution and communication. 

The cost parameter is optional at the moment to maintain compatibility with older cluster config files. The cost defaults to 1.0 if it is not specified. An example config file with 4 cpus and arbitrary costs for each of them has been added. Nodes with a higher cost are assigned a smaller chunk of the iteration space. This is calculated using a normalized weight parameter where each weight is equal to (1/cost) before normalization. There is a compile-time check to ensure cost is not equal to 0.

A createBuildRankToNodeMapFunc function creates a runtime function that uses MPI_Get_processor_name() to obtain the hostname of the node the rank is currently running on. Currently, we use the node_ids from the cluster config file as the hostnames. The hostname obtained from each rank is compared against the hostnames available in the DLTI attributes by emitting a series of runtime strcmp() calls. Each rank determines a matching node and its index in the config file structure for itself. Then we use an MPI_Allgather() operation so each rank has information about each rank and its matched node index. Each rank then independently constructs a rankToNodeMap and a nodeToRankMap at runtime. We allow all ranks to construct both mappings in case we later have to send information between different nodes. The rankToNodeMap is used to determine which tasks should execute on a given rank since the scheduler assigns tasks to nodes based on cost. The nodeToRankMap is required for communication and distribution of required data. We preserve the current behavior by keeping node0 as the initial source of data. Required data is distributed using the runtime nodeToRankMap. However, this is parameterized using rootRank so this behavior can be extended when needed. 

Currently, there is no representation for MPI_Get_processor_name() and MPI_Allgather() in the MLIR MPI dialect. The mpi.allgather operation has been added in a recent patch and is present on the main branch of the llvm-project (https://github.com/llvm/llvm-project/blob/b115dd117ac109ac501b8bc044dbdefd6f5f2471/mlir/include/mlir/Dialect/MPI/IR/MPIOps.td#L266). However, this is not on any stable release branch yet.

Considering these factors, the MPI_Get_processor_name(), MPI_Allgather() and strcmp calls are emitted directly in the MLIR LLVM IR dialect. The LLVM IR call for MPI_Allgather() is specific to the MPI implementation. For now, I have hardcoded MPICH specific constants. Once MPI_Allgather() is present on a stable branch we can move to using mpi.allgather which could be more implementation agnostic. 